### PR TITLE
store.add and store.put calls fail when store has a keyPath specified

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -258,10 +258,14 @@
             //this._track_transaction(writeTransaction);
             var store = writeTransaction.objectStore(storeName);
             var json = object.toJSON();
+            var writeRequest;
 
             if (!json.id) json.id = guid();
 
-            var writeRequest = store.add(json, json.id);
+            if (!store.keyPath)
+              writeRequest = store.add(json, json.id);
+            else
+              writeRequest = store.add(json);
 
             writeRequest.onerror = function (e) {
                 options.error(e);
@@ -278,10 +282,14 @@
             //this._track_transaction(writeTransaction);
             var store = writeTransaction.objectStore(storeName);
             var json = object.toJSON();
+            var writeRequest;
 
             if (!json.id) json.id = guid();
 
-            var writeRequest = store.put(json, json.id);
+            if (!store.keyPath)
+              writeRequest = store.put(json, json.id);
+            else
+              writeRequest = store.put(json);
 
             writeRequest.onerror = function (e) {
                 options.error(e);

--- a/tests/test.html
+++ b/tests/test.html
@@ -22,16 +22,9 @@
             }]
         };
 
-        var databasev2 = {
-            id: "movies-database",
-            description: "The database for the Movies",
-            migrations: [{
-                version: 1,
-                migrate: function (transaction, next) {
-                    var store = transaction.db.createObjectStore("movies");
-                    next();
-                }
-            }, {
+        var databasev2 = $.extend(true, {}, databasev1);
+        databasev2.migrations.push(
+            {
                 version: 2,
                 migrate: function (transaction, next) {
                     var store = undefined;
@@ -48,7 +41,18 @@
                     next();
                 }
             }
-        ]};
+        );
+
+        var databasev3 = $.extend(true, {}, databasev2);
+        databasev3.migrations.push(
+            {
+                version: 3,
+                migrate: function (transaction, next) {
+                    var store = transaction.db.createObjectStore("torrents", {keyPath: "id"});
+                    next();
+                }
+            }
+        );
 
         var Moviev1 = Backbone.Model.extend({
             database: databasev1,
@@ -58,6 +62,11 @@
         var Movie = Backbone.Model.extend({
             database: databasev2,
             storeName: "movies"
+        });
+
+        var Torrent = Backbone.Model.extend({
+            database: databasev3,
+            storeName: "torrents"
         });
 
         var Theater = Backbone.Collection.extend({
@@ -688,6 +697,55 @@
               start();
               equals(typeof Backbone.ajaxSync,'function', "should not be the original Backbone.sync function" );
               nextTest();
+            }],
+            ["model add with keyPath specified", function(){
+                var torrent = new Torrent();
+                torrent.isnew = function() { return true};
+                torrent.save({
+                    id: 1,
+                    title: "The Matrix",
+                    format: "dvd"
+                }, {
+                    success: function () {
+                        start();
+                        equals(true, true, "The torrent should be added successfully");
+                        nextTest();
+                    },
+                    error: function (o, error) {
+                        start();
+                        if (window.console && window.console.log) window.console.log(error);
+                        equals(true, false, error.error.target.webkitErrorMessage);
+                        nextTest();
+                    }
+                });
+            }],
+            ["model update with keyPath specified", function(){
+                var torrent = new Torrent({id: 1});
+                torrent.fetch({
+                    success: function () {
+                        start();
+                        equals("The Matrix", torrent.get("title"), "The torrent should be fetched successfully");
+                        torrent.save({rating: 5}, {
+                          success: function() {
+                            start();
+                            equals(true, true, "The torrent should be updated succesfully");
+                            nextTest();
+                          },
+                          error: function (o, error) {
+                              start();
+                              if (window.console && window.console.log) window.console.log(error);
+                              equals(true, false, error.error.target.webkitErrorMessage);
+                              nextTest();
+                          }
+                        });
+                    },
+                    error: function (o, error) {
+                        start();
+                        if (window.console && window.console.log) window.console.log(error);
+                        equals(true, false, error.error.target.webkitErrorMessage);
+                        nextTest();
+                    }
+                });
             }]
         ];
 


### PR DESCRIPTION
as per spec of store.add and store.put [http://www.w3.org/TR/IndexedDB/#widl-IDBObjectStore-add-IDBRequest-any-value-any-key]

"this method throws a DOMException of type DataError:

The object store uses in-line keys and the key parameter was provided."

This fixes the add and put calls to conditionally provide the key parameter after checking store.keyPath
