### PR TITLE
Added possibility to use autoIncrement keys

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -253,8 +253,9 @@
             var json = object.toJSON();
             var writeRequest;
 
-            if (!json.id) json.id = guid();
-
+            if (json.id === undefined) json.id = guid();
+            if (json.id === null) delete json.id;
+            
             if (!store.keyPath)
               writeRequest = store.add(json, json.id);
             else


### PR DESCRIPTION
When using autoIncrement originally you must pass `object.id=undefined` to the indexeddb to let it generate a key automatically for you.

But the indexeddb-backbone-adapter will automatically generate a GUID for you which is usually not intended when using a autoIncrement key.

This patch makes it possible to use `data.id=null` instead of `data.id=undefined` to let autoIncrement generate a key for you and prevent indexeddb-backbone-adapter to generate a GUID.
