### PR TITLE
Fix for google closure compiler errors.

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -338,7 +338,7 @@
             var store = deleteTransaction.objectStore(storeName);
             var json = object.toJSON();
 
-            var deleteRequest = store.remove(json.id);
+            var deleteRequest = store['delete'].call(store, json.id);
             deleteRequest.onsuccess = function (event) {
                 options.success(null);
             };
@@ -445,7 +445,7 @@
                             if (options.addIndividually) {
                                 collection.add(cursor.value);
                             } else if (options.clear) {
-                                var deleteRequest = store.remove(cursor.value.id);
+                                var deleteRequest = store['delete'].call(store, cursor.value.id);
                                 deleteRequest.onsuccess = function (event) {
                                     elements.push(cursor.value);
                                 };


### PR DESCRIPTION
Google closure compiler fails due to the method names "continue" and "delete" clashing with the reserved keywords.

1) Applied workaround: var closure_continue = closure['continue']

2) Renamed Driver.prototype.delete to Driver.prototype.remove
