### PR TITLE
option.error callback wrapping bugfix.

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -572,7 +572,7 @@
         var error = options.error;
         options.error = function(resp) {
             reject();
-            if (error) error(object, resp, options);
+            if (error) error(resp, options);
             object.trigger('error', object, resp, options);
         };
         


### PR DESCRIPTION
Same issue as with the option.success callback wrapping.
