### PR TITLE
Tests now run flawlessly on both Firefox and Chrome

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -268,7 +268,7 @@
             writeRequest.onerror = function (e) {
                 options.error(e);
             };
-            writeRequest.onsuccess = function (e) {
+            writeTransaction.oncomplete = function (e) {
                 options.success(json);
             };
         },
@@ -292,7 +292,7 @@
             writeRequest.onerror = function (e) {
                 options.error(e);
             };
-            writeRequest.onsuccess = function (e) {
+            writeTransaction.oncomplete = function (e) {
                 options.success(json);
             };
         },
@@ -342,7 +342,8 @@
             var json = object.toJSON();
 
             var deleteRequest = store.delete(json.id);
-            deleteRequest.onsuccess = function (event) {
+
+            deleteTransaction.oncomplete = function (event) {
                 options.success(null);
             };
             deleteRequest.onerror = function (event) {


### PR DESCRIPTION
It seems Chrome really wants us to use the transaction.oncomplete callbacks instead of request.success callbacks. Tested with both recent Firefox and Chrome versions, and test then run fine. Using the request.success callbacks on Chrome on write requests leads to indeterministic behaviour (probably related to subsequent reads being done before writes have been completed and commited to the database).
