### PR TITLE
Use ajaxSync if no database is specified

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -541,6 +541,11 @@
             return;
         }
 
+        // If a model or a collection does not define a database, fall back on ajaxSync
+        if (typeof object.database === 'undefined' && typeof Backbone.ajaxSync === 'function'){
+            return Backbone.ajaxSync(method, object, options);
+        }
+
         var schema = object.database;
         if (Databases[schema.id]) {
             if(Databases[schema.id].version != _.last(schema.migrations).version){

--- a/tests/mockAjax.json
+++ b/tests/mockAjax.json
@@ -1,0 +1,10 @@
+[
+	{
+		"prop1" : "val1",
+		"prop1.2" : "val2"
+	},
+	{
+		"prop1" : "val1",
+		"prop2.1" : "val2"
+	}
+]

--- a/tests/test.html
+++ b/tests/test.html
@@ -744,6 +744,29 @@
                         nextTest();
                     }
                 });
+            }],
+            ["Use AjaxSync when no database is specified", function(){
+                var testModel = Backbone.Model.extend({});
+
+                var testCollection = Backbone.Collection.extend({
+                    model: testModel,
+                    url: "mockAjax.json"
+                });
+
+                var testCollectionInstance = new testCollection();
+
+                testCollectionInstance.fetch({
+                    success: function(){
+                        start();
+                        equal(testCollectionInstance.length, 2, "Collection successfully fetched");
+                        nextTest();
+                    },
+                    error : function(){
+                        start();
+                        ok(false, "Collection not fetched");
+                        nextTest();
+                    }
+                });
             }]
         ];
 


### PR DESCRIPTION
If in a collection or a model, no database field is specified, fallback on ajax sync. This will enable only certain models of a project to be saved in IndexedDB while others can still be synced. Will make existing projects adapt this easily.

Added in this commit
- Logic to fall back on ajaxSync
- Added test case for it
- Mock Ajax to test ajaxSync.
