### PR TITLE
Fix bug with migration. cleanup code.

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -40,8 +40,9 @@
         this.dbRequest      = indexedDB.open(this.schema.id,lastMigrationPathVersion); //schema version need to be an unsigned long
 
         this.launchMigrationPath = function(dbVersion) {
+            var transaction = this.dbRequest.transaction || versionRequest.result;
             var clonedMigrations = _.clone(schema.migrations);
-            this.migrate(clonedMigrations, dbVersion, {
+            this.migrate(transaction, clonedMigrations, dbVersion, {
                 success: function () {
                     this.ready();
                 }.bind(this),
@@ -127,14 +128,8 @@
         },
 
         // Performs all the migrations to reach the right version of the database.
-        migrate: function (migrations, version, options) {
-            if (!this.nolog) debugLog("Starting migrations from " + version);
-            this._migrate_next(migrations, version, options);
-        },
-
-        // Performs the next migrations. This method is private and should probably not be called.
-        _migrate_next: function (migrations, version, options) {
-            if (!this.nolog) debugLog("_migrate_next begin version from #" + version);
+        migrate: function (transaction, migrations, version, options) {
+            if (!this.nolog) debugLog("migrate begin version from #" + version);
             var that = this;
             var migration = migrations.shift();
             if (migration) {
@@ -151,22 +146,19 @@
                         };
                     }
                     // First, let's run the before script
-                    if (!this.nolog) debugLog("_migrate_next begin before version #" + migration.version);
+                    if (!this.nolog) debugLog("migrate begin before version #" + migration.version);
                     migration.before(function () {
-                        if (!this.nolog) debugLog("_migrate_next done before version #" + migration.version);
+                        if (!this.nolog) debugLog("migrate done before version #" + migration.version);
 
                         var continueMigration = function (e) {
-                            if (!this.nolog) debugLog("_migrate_next continueMigration version #" + migration.version);
-
-                            var transaction = this.dbRequest.transaction || versionRequest.result;
-                            if (!this.nolog) debugLog("_migrate_next begin migrate version #" + migration.version);
+                            if (!this.nolog) debugLog("migrate begin migrate version #" + migration.version);
 
                             migration.migrate(transaction, function () {
-                                if (!this.nolog) debugLog("_migrate_next done migrate version #" + migration.version);
+                                if (!this.nolog) debugLog("migrate done migrate version #" + migration.version);
                                 // Migration successfully appliedn let's go to the next one!
-                                if (!this.nolog) debugLog("_migrate_next begin after version #" + migration.version);
+                                if (!this.nolog) debugLog("migrate begin after version #" + migration.version);
                                 migration.after(function () {
-                                    if (!this.nolog) debugLog("_migrate_next done after version #" + migration.version);
+                                    if (!this.nolog) debugLog("migrate done after version #" + migration.version);
                                     if (!this.nolog) debugLog("Migrated to " + migration.version);
 
                                     //last modification occurred, need finish
@@ -177,9 +169,9 @@
                                             options.success();
                                         }
                                         else{*/
-                                            if (!this.nolog) debugLog("_migrate_next setting transaction.oncomplete to finish  version #" + migration.version);
+                                            if (!this.nolog) debugLog("migrate setting transaction.oncomplete to finish  version #" + migration.version);
                                             transaction.oncomplete = function() {
-                                                if (!that.nolog) debugLog("_migrate_next done transaction.oncomplete version #" + migration.version);
+                                                if (!that.nolog) debugLog("migrate done transaction.oncomplete version #" + migration.version);
 
                                                 if (!that.nolog) debugLog("Done migrating");
                                                 // No more migration
@@ -189,11 +181,8 @@
                                     }
                                     else
                                     {
-                                        if (!this.nolog) debugLog("_migrate_next setting transaction.oncomplete to recursive _migrate_next  version #" + migration.version);
-                                        transaction.oncomplete = function() {
-                                           if (!this.nolog) debugLog("_migrate_next end from version #" + version + " to " + migration.version);
-                                           that._migrate_next(migrations, version, options);
-                                       }
+                                        if (!this.nolog) debugLog("migrate end from version #" + version + " to " + migration.version);
+                                            that.migrate(transaction, migrations, version, options);
                                     }
 
                                 }.bind(this));
@@ -201,7 +190,7 @@
                         }.bind(this);
 
                         if(!this.supportOnUpgradeNeeded){
-                            if (!this.nolog) debugLog("_migrate_next begin setVersion version #" + migration.version);
+                            if (!this.nolog) debugLog("migrate begin setVersion version #" + migration.version);
                             var versionRequest = this.db.setVersion(migration.version);
                             versionRequest.onsuccess = continueMigration;
                             versionRequest.onerror = options.error;
@@ -214,7 +203,7 @@
                 } else {
                     // No need to apply this migration
                     if (!this.nolog) debugLog("Skipping migration " + migration.version);
-                    this._migrate_next(migrations, version, options);
+                    this.migrate(transaction, migrations, version, options);
                 }
             }
         },


### PR DESCRIPTION
Hi,

I've been having a bug where `DOM IDBDatabase Exception 11` was being thrown out during my second migration.

Turned out the bug can be fixed by not waiting for `transaction.oncomplete` to fire next migration.

More specifically, `transaction.oncomplete` seems to be dependent upon the GC:

> The following sentence isn't correct "Transactions today auto-commit when the transaction variable goes out of 
> scope and no more requests can be placed against it".

Since the JS GC sucks really bad, it's always a good idea to keep the transaction variable around if one wants to avoid an unfortunate `oncomplete` callback. (indeed calling `this.transaction` will fall out of the GC scope, thus `transaction` may be considered out of scope..)

I have thus added `transaction` as the first variable of the migration function. Also, it turned out that `migrate` was just a proxy for `_migrate_next` so I've removed `_migrate_next`.
