### PR TITLE
Scope _ and Backbone variables using the 'var' keyword

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -9,9 +9,13 @@
         return (S4() + S4() + "-" + S4() + "-" + S4() + "-" + S4() + "-" + S4() + S4() + S4());
     }
 
+    var Backbone, _;
     if(typeof exports !== 'undefined'){
         _ = require('underscore');
         Backbone = require('backbone');
+    } else {
+        _ = window._;
+        Backbone = window.Backbone;
     }
 
 


### PR DESCRIPTION
Scope _ and Backbone variables using the 'var' keyword. If exports is undefined, then get them from the 'window' object explicitly.

While not absolutely necessary, this fixes a couple of warnings in PyCharm.
