### PR TITLE
Fulfil optional jQuery dependency from Backbone.$ instead of the global $ object.

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -569,7 +569,7 @@
         var promise;
         var noop = function() {};
 
-        if (typeof(Backbone.$) != 'undefined' && Backbone.$.Deferred) {
+        if (typeof Backbone.$ !== 'undefined' && typeof Backbone.$.Deferred !== 'undefined') {
             var dfd = Backbone.$.Deferred();
             var resolve = dfd.resolve;
             var reject = dfd.reject;


### PR DESCRIPTION
Fulfil optional jQuery dependency from Backbone.$ instead of the global $ object.

If jQuery is used with Backbonejs, then it should be available as `Backbone.$`. Since we're already using `require()` to get Backbone, but do not want to create a hard dependency on jQuery, it's better to refer to `Backbone.$` instead of relying on a global `$` object.
