### PR TITLE
Fulfill the optional jQuery dependency from Backbone.$

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -567,17 +567,17 @@
         }
 
         var promise;
-        var noop = function() {};
 
-        if (typeof($) != 'undefined' && $.Deferred) {
-            var dfd = $.Deferred();
+        if (typeof Backbone.$ === 'undefined' || typeof Backbone.$.Deferred === 'undefined') {
+            var noop = function() {};
+            var resolve = noop;
+            var reject = noop;
+        } else {
+            var dfd = Backbone.$.Deferred();
             var resolve = dfd.resolve;
             var reject = dfd.reject;
 
             promise = dfd.promise();
-        } else {
-            var resolve = noop;
-            var reject = noop;
         }
 
         var success = options.success;


### PR DESCRIPTION
No longer looks for `$` on the global object, but on `Backbone.$` instead. Inverted the check for `$.Deferred`. Moved the `noop` initialization into the block in which it is used.
