### PR TITLE
remove prefixed indexedDB fallbacks

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -23,13 +23,6 @@
         return (S4() + S4() + "-" + S4() + "-" + S4() + "-" + S4() + "-" + S4() + S4() + S4());
     }
 
-     // Naming is a mess!
-     var indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.msIndexedDB ;
-     var IDBTransaction = window.IDBTransaction || window.webkitIDBTransaction || { READ_WRITE: "readwrite" }; // No prefix in moz
-     var IDBKeyRange = window.IDBKeyRange || window.webkitIDBKeyRange ; // No prefix in moz
-
-     window.IDBCursor = window.IDBCursor || window.webkitIDBCursor ||  window.mozIDBCursor ||  window.msIDBCursor ;
-
     if ( _(indexedDB).isUndefined() ) { return; }
     
     // Driver object


### PR DESCRIPTION
I am sending this in as a way to discuss this. 

I believe the decision to fall back  on prefixed implementions of _indexedDB_ should be left to the user of the library. In this case it could be suggested that they do the renaming of the prefixed before loading any of the other scripts:

```
     var indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.msIndexedDB ;
     var IDBTransaction = window.IDBTransaction || window.webkitIDBTransaction || { READ_WRITE: "readwrite" }; // No prefix in moz
     var IDBKeyRange = window.IDBKeyRange || window.webkitIDBKeyRange ; // No prefix in moz

     window.IDBCursor = window.IDBCursor || window.webkitIDBCursor ||  window.mozIDBCursor ||  window.msIDBCursor ;

// --> load backbone-indexeddb here
```

Browser support: http://caniuse.com/indexeddb
