### PR TITLE
Check for indexedDb inside window object

### DIFF
--- a/backbone-indexeddb.js
+++ b/backbone-indexeddb.js
@@ -23,7 +23,7 @@
         return (S4() + S4() + "-" + S4() + "-" + S4() + "-" + S4() + "-" + S4() + S4() + S4());
     }
 
-    if ( _(indexedDB).isUndefined() ) { return; }
+    if ( _(window.indexedDB).isUndefined() ) { return; }
     
     var Deferred = Backbone.$ && Backbone.$.Deferred;
 


### PR DESCRIPTION
PhantomJS breaks on this check (I'm using it to run unit tests), unless we check it inside `window`